### PR TITLE
AboutUs.md: Rename "Teee728" to "teee728"

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -30,7 +30,7 @@ We are a team based in the [School of Computing, National University of Singapor
 
 ### Tresa
 
-<img src="images/Teee728.png" width="200px">
+<img src="images/teee728.png" width="200px">
 
 [[github](http://github.com/Teee728)]
 


### PR DESCRIPTION
PR #36 renamed `docs/images/Teee728.png` to `teee728.png`, but the About Us page was not updated to reflect this change, leading to a broken image link when viewing the website.