### PR TITLE
Add command history

### DIFF
--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -10,13 +10,32 @@ import java.util.List;
  */
 public class CommandHistory {
     // TODO: let user specify history size in preferences.json
-    private static final int HISTORY_SIZE = 100;
+    private int capacity = 100;
 
     /**
      * The list for storing the commands.
      */
     // TODO: (Enhancement) persist command history between app launches
     private final LinkedList<String> history = new LinkedList<>();
+
+    /**
+     * Instantiates a new CommandHistory with the default capacity.
+     */
+    public CommandHistory() {
+        super();
+    }
+
+    /**
+     * Instantiates a new CommandHistory with the specified capacity.
+     *
+     * @param size A non-negative integer representing the maximum number of entries to store.
+     */
+    public CommandHistory(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException("Capacity for command history cannot be negative.");
+        }
+        this.capacity = size;
+    }
 
     /**
      * Returns a read-only list of the command history, starting with the most recent command
@@ -35,10 +54,13 @@ public class CommandHistory {
      * @param entry the entry
      */
     public void add(String entry) {
+        if (entry == null) {
+            throw new IllegalArgumentException("String argument cannot be null");
+        }
         history.addFirst(entry);
-        if (history.size() > HISTORY_SIZE) {
+        if (history.size() > capacity) {
             history.pollLast();
         }
-        assert history.size() <= HISTORY_SIZE : "Size of command history should not be over the limit";
+        assert history.size() <= capacity : "Size of command history should not be over the limit";
     }
 }

--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -1,0 +1,42 @@
+package seedu.address.logic;
+
+import java.util.LinkedList;
+
+/**
+ * A list of previously executed commands. Only the most recent {@code HISTORY_SIZE}
+ * commands are kept in the list.
+ */
+public class CommandHistory {
+    // TODO: let user specify history size in preferences.json
+    private static final int HISTORY_SIZE = 100;
+
+    /**
+     * The list for storing the commands.
+     */
+    // TODO: (Enhancement) persist command history between app launches
+    private final LinkedList<String> history = new LinkedList<>();
+
+    /**
+     * Retrieves the command history, starting with the most recent command
+     * at the first index.
+     *
+     * @return a list of commands
+     */
+    public LinkedList<String> getHistory() {
+        return history;
+    }
+
+    /**
+     * Add a command to the history. If the list is already at capacity,
+     * the oldest command will be evicted.
+     *
+     * @param entry the entry
+     */
+    public void add(String entry) {
+        history.add(entry);
+        if (history.size() > HISTORY_SIZE) {
+            history.pop();
+        }
+        assert history.size() <= HISTORY_SIZE : "Size of command history should not be over the limit";
+    }
+}

--- a/src/main/java/seedu/address/logic/CommandHistory.java
+++ b/src/main/java/seedu/address/logic/CommandHistory.java
@@ -1,6 +1,8 @@
 package seedu.address.logic;
 
+import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 
 /**
  * A list of previously executed commands. Only the most recent {@code HISTORY_SIZE}
@@ -17,13 +19,13 @@ public class CommandHistory {
     private final LinkedList<String> history = new LinkedList<>();
 
     /**
-     * Retrieves the command history, starting with the most recent command
+     * Returns a read-only list of the command history, starting with the most recent command
      * at the first index.
      *
      * @return a list of commands
      */
-    public LinkedList<String> getHistory() {
-        return history;
+    public List<String> getHistory() {
+        return Collections.unmodifiableList(history);
     }
 
     /**
@@ -33,9 +35,9 @@ public class CommandHistory {
      * @param entry the entry
      */
     public void add(String entry) {
-        history.add(entry);
+        history.addFirst(entry);
         if (history.size() > HISTORY_SIZE) {
-            history.pop();
+            history.pollLast();
         }
         assert history.size() <= HISTORY_SIZE : "Size of command history should not be over the limit";
     }

--- a/src/main/java/seedu/address/logic/CommandHistoryView.java
+++ b/src/main/java/seedu/address/logic/CommandHistoryView.java
@@ -1,0 +1,61 @@
+package seedu.address.logic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Manager for viewing and editing the command history. It uses a buffer to keep track of changes made
+ * to the command history in the current input session, but does not modify the actual command history.
+ */
+public class CommandHistoryView {
+    private int index = 0;
+    private final List<String> commandBuffer = new ArrayList<>();
+
+    /**
+     * Instantiates a new Command history view.
+     *
+     * @param history        the history
+     */
+    public CommandHistoryView(CommandHistory history) {
+        commandBuffer.add("");
+        commandBuffer.addAll(history.getHistory());
+    }
+
+    /**
+     * Request for the next entry in the history.
+     *
+     * @return an {@code Optional<String>} containing next entry if it exists,
+     * {@link Optional#empty()} otherwise.
+     */
+    public Optional<String> next() {
+        if (index + 1 == commandBuffer.size()) {
+            return Optional.empty();
+        }
+        index += 1;
+        return Optional.of(commandBuffer.get(index));
+    }
+
+    /**
+     * Request for the previous entry in the history.
+     *
+     * @return an {@code Optional<String>} containing the previous entry if it exists,
+     * {@link Optional#empty()} otherwise.
+     */
+    public Optional<String> previous() {
+        if (index == 0) {
+            return Optional.empty();
+        }
+        index -= 1;
+        return Optional.of(commandBuffer.get(index));
+    }
+
+    /**
+     * Update the current command in the buffer.
+     *
+     * @param command the command to update.
+     */
+    public void updateCurrentCommand(String command) {
+        commandBuffer.set(index, command);
+    }
+}

--- a/src/main/java/seedu/address/logic/CommandHistoryView.java
+++ b/src/main/java/seedu/address/logic/CommandHistoryView.java
@@ -18,6 +18,9 @@ public class CommandHistoryView {
      * @param history        the history
      */
     public CommandHistoryView(CommandHistory history) {
+        if (history == null) {
+            throw new IllegalArgumentException("Command history cannot be null");
+        }
         commandBuffer.add("");
         commandBuffer.addAll(history.getHistory());
     }
@@ -56,6 +59,9 @@ public class CommandHistoryView {
      * @param command the command to update.
      */
     public void updateCurrentCommand(String command) {
+        if (command == null) {
+            throw new IllegalArgumentException("String command cannot be null.");
+        }
         commandBuffer.set(index, command);
     }
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -6,6 +6,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.CommandHistory;
+import seedu.address.logic.CommandHistoryView;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -22,6 +23,8 @@ public class CommandBox extends UiPart<Region> {
 
     private final CommandHistory history;
 
+    private CommandHistoryView historyView;
+
     @FXML
     private TextField commandTextField;
 
@@ -32,6 +35,7 @@ public class CommandBox extends UiPart<Region> {
         super(FXML);
         this.commandExecutor = commandExecutor;
         this.history = history;
+        this.historyView = new CommandHistoryView(history);
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
 
@@ -55,19 +59,31 @@ public class CommandBox extends UiPart<Region> {
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
+        } finally {
+            // reset the history viewer
+            historyView = new CommandHistoryView(history);
         }
-        System.out.println(history.getHistory());
     }
 
     private void addArrowKeyHandler() {
         this.getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            String commandText = commandTextField.getText();
+
             switch(event.getCode()) {
             case UP:
-                //handle up
+                historyView.updateCurrentCommand(commandText);
+                historyView.next().ifPresent(nextCommand -> {
+                    commandTextField.setText(nextCommand);
+                    commandTextField.positionCaret(nextCommand.length());
+                });
                 event.consume();
                 break;
             case DOWN:
-                //handle down
+                historyView.updateCurrentCommand(commandText);
+                historyView.previous().ifPresent(nextCommand -> {
+                    commandTextField.setText(nextCommand);
+                    commandTextField.positionCaret(nextCommand.length());
+                });
                 event.consume();
                 break;
             default:

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -5,6 +5,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -19,15 +20,18 @@ public class CommandBox extends UiPart<Region> {
 
     private final CommandExecutor commandExecutor;
 
+    private final CommandHistory history;
+
     @FXML
     private TextField commandTextField;
 
     /**
      * Creates a {@code CommandBox} with the given {@code CommandExecutor}.
      */
-    public CommandBox(CommandExecutor commandExecutor) {
+    public CommandBox(CommandExecutor commandExecutor, CommandHistory history) {
         super(FXML);
         this.commandExecutor = commandExecutor;
+        this.history = history;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
 
@@ -46,10 +50,13 @@ public class CommandBox extends UiPart<Region> {
 
         try {
             commandExecutor.execute(commandText);
+            // command should only be added to history if execution results in no exceptions.
+            history.add(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
+        System.out.println(history.getHistory());
     }
 
     private void addArrowKeyHandler() {

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -29,6 +30,8 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+
+        addArrowKeyHandler();
     }
 
     /**
@@ -47,6 +50,23 @@ public class CommandBox extends UiPart<Region> {
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }
+    }
+
+    private void addArrowKeyHandler() {
+        this.getRoot().addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            switch(event.getCode()) {
+            case UP:
+                //handle up
+                event.consume();
+                break;
+            case DOWN:
+                //handle down
+                event.consume();
+                break;
+            default:
+                // KeyEvent is not consumed and will continue propagating down.
+            }
+        });
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -12,6 +12,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.CommandHistory;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -119,7 +120,7 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand);
+        CommandBox commandBox = new CommandBox(this::executeCommand, new CommandHistory());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 

--- a/src/test/java/seedu/address/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/logic/CommandHistoryTest.java
@@ -1,0 +1,90 @@
+package seedu.address.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class CommandHistoryTest {
+    @Test
+    public void constructor_default() {
+        CommandHistory history = new CommandHistory();
+        assertNotNull(history);
+        assertEquals(Collections.emptyList(), history.getHistory());
+    }
+
+    @Test
+    public void constructor_withCapacity() {
+        CommandHistory history = new CommandHistory(5);
+        assertNotNull(history);
+        assertEquals(Collections.emptyList(), history.getHistory());
+    }
+
+    @Test
+    public void constructor_withCapacity_negativeSize_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new CommandHistory(-5));
+    }
+
+    @Test
+    public void execute_addAndReadSingleCommand() {
+        CommandHistory history = new CommandHistory(5);
+        assertEquals(Collections.emptyList(), history.getHistory());
+        history.add("command");
+        assertEquals(1, history.getHistory().size());
+        assertEquals("command", history.getHistory().get(0));
+    }
+
+    @Test
+    public void adding_nullCommand_throwsIllegalArgumentException() {
+        CommandHistory history = new CommandHistory(5);
+        assertThrows(IllegalArgumentException.class, () -> history.add(null));
+    }
+
+    @Test
+    public void execute_addAndReadMultipleCommands() {
+        CommandHistory history = new CommandHistory(10);
+        assertEquals(Collections.emptyList(), history.getHistory());
+        List<String> input = Arrays.asList("1", "2", "3", "4", "5");
+        for (String s : input) {
+            history.add(s);
+        }
+        assertEquals(5, history.getHistory().size());
+        Collections.reverse(input);
+        assertEquals(input, history.getHistory());
+    }
+
+    @Test
+    public void execute_addBeyondCapacity() {
+        CommandHistory history = new CommandHistory(5);
+        List<String> first = Arrays.asList("1", "2", "3", "4", "5");
+        for (String s : first) {
+            history.add(s);
+        }
+        List<String> second = Arrays.asList("a", "b", "c", "d", "e");
+        for (String s : second) {
+            history.add(s);
+        }
+        assertEquals(5, history.getHistory().size());
+        Collections.reverse(second);
+        assertEquals(second, history.getHistory());
+    }
+
+    @Test
+    public void check_zero_capacity() {
+        CommandHistory history = new CommandHistory(0);
+        history.add("command");
+        assertEquals(Collections.emptyList(), history.getHistory());
+    }
+
+    @Test
+    public void check_modifyingEntries_throwsUnsupportedOperationException() {
+        CommandHistory history = new CommandHistory(1);
+        history.add("command");
+        assertThrows(UnsupportedOperationException.class, () -> history.getHistory().set(0, "newcommand"));
+    }
+}

--- a/src/test/java/seedu/address/logic/CommandHistoryViewTest.java
+++ b/src/test/java/seedu/address/logic/CommandHistoryViewTest.java
@@ -1,0 +1,97 @@
+package seedu.address.logic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class CommandHistoryViewTest {
+    @Test
+    public void constructor_nullArg_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> new CommandHistoryView(null));
+    }
+
+    @Test
+    public void navigateToEndOfHistory_success() {
+        CommandHistory history = new CommandHistory();
+        List<String> first = Arrays.asList("1", "2", "3");
+        for (String s : first) {
+            history.add(s);
+        }
+        CommandHistoryView view = new CommandHistoryView(history);
+        assertEquals(Optional.of("3"), view.next());
+        assertEquals(Optional.of("2"), view.next());
+        assertEquals(Optional.of("1"), view.next());
+        assertEquals(Optional.empty(), view.next());
+        assertEquals(Optional.empty(), view.next());
+    }
+
+    @Test
+    public void updateCurrentCommand_success() {
+        CommandHistory history = new CommandHistory();
+        CommandHistoryView view = new CommandHistoryView(history);
+        assertEquals(1, getCommandHistoryViewBuffer(view).size());
+        assertEquals("", getCommandHistoryViewBuffer(view).get(0));
+        view.updateCurrentCommand("Command");
+        assertEquals(1, getCommandHistoryViewBuffer(view).size());
+        assertEquals("Command", getCommandHistoryViewBuffer(view).get(0));
+    }
+
+    @Test
+    public void updatePersistsAfterNavigation_success() {
+        CommandHistory history = new CommandHistory();
+        List<String> first = Arrays.asList("1", "2", "3");
+        for (String s : first) {
+            history.add(s);
+        }
+        CommandHistoryView view = new CommandHistoryView(history);
+        assertEquals(4, getCommandHistoryViewBuffer(view).size());
+        assertEquals(Arrays.asList("", "3", "2", "1"), getCommandHistoryViewBuffer(view));
+        view.next();
+        view.next();
+        view.updateCurrentCommand("updated");
+        view.previous();
+        assertEquals(4, getCommandHistoryViewBuffer(view).size());
+        assertEquals(Arrays.asList("", "3", "updated", "1"), getCommandHistoryViewBuffer(view));
+    }
+
+    @Test
+    public void modifyingCommandHistoryAfterPassingIntoConstructor_noEffect() {
+        CommandHistory history = new CommandHistory();
+        List<String> first = Arrays.asList("1", "2", "3");
+        for (String s : first) {
+            history.add(s);
+        }
+        CommandHistoryView view = new CommandHistoryView(history);
+        assertEquals(4, getCommandHistoryViewBuffer(view).size());
+        assertEquals(Arrays.asList("", "3", "2", "1"), getCommandHistoryViewBuffer(view));
+        history.add("4");
+        assertEquals(4, getCommandHistoryViewBuffer(view).size());
+        assertEquals(Arrays.asList("", "3", "2", "1"), getCommandHistoryViewBuffer(view));
+    }
+
+    @Test
+    public void updatingCommand_nullArg_throwsIllegalArgumentException() {
+        CommandHistory history = new CommandHistory();
+        CommandHistoryView view = new CommandHistoryView(history);
+        assertThrows(IllegalArgumentException.class, () -> view.updateCurrentCommand(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ArrayList<String> getCommandHistoryViewBuffer(CommandHistoryView view) {
+        try {
+            Field privateField = CommandHistoryView.class.getDeclaredField("commandBuffer");
+            privateField.setAccessible(true);
+            return (ArrayList<String>) privateField.get(view);
+        } catch (Exception e) {
+            System.out.println("Error when using reflection to access private field in CommandHistoryView.");
+        }
+        return new ArrayList<>();
+    }
+}


### PR DESCRIPTION
When entering a command, the up and down arrow keys can be used to view
previously entered commands. Additionally, any change to a command is
saved when navigating to another command, so that the user is able to
navigate to a previous command to refer to it, and return back to their
new command to finish it.