### PR TITLE
Update FXML id in ContactListPanel.fxml

### DIFF
--- a/src/main/resources/view/ContactListPanel.fxml
+++ b/src/main/resources/view/ContactListPanel.fxml
@@ -4,5 +4,5 @@
 <?import javafx.scene.layout.VBox?>
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+  <ListView fx:id="contactListView" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
There was a mismatch in the FXML ids in ContactListPanel.java and ContactListPanel.fxml, leading to an error when the application was launched as the controller received a null reference instead of an FXML object.