### PR TITLE
Fix telegram alerts for PRs 

### DIFF
--- a/.github/workflows/telegram-alerts.yml
+++ b/.github/workflows/telegram-alerts.yml
@@ -1,7 +1,7 @@
 name: Telegram Pull Request Notifier
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, review_requested]
 
 jobs:


### PR DESCRIPTION
Changed workflow target to `pull_request_target`, which allows secrets to be read when PRs from forks are created.