### PR TITLE
Change shadowJar file name to "CodeConnect.jar"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'CodeConnect.jar'
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Updates `build.gradle` so that our project's generated JAR file matches our product name.