### PR TITLE
Set limitations to tech stack and tags

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -141,7 +141,8 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS g/GITHUB_USERNAME [t/TAG] p
 
 <box type="tip" seamless>
 
-**Tip:** A contact can have any number of tags and tech stack (including 0)
+**Tip:**
+- Note that tags and tech stacks are limited to 15 characters per label and a maximum of 3 each per contact.
 </box>
 
 Examples:

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -136,8 +136,11 @@ public class ParserUtil {
         String trimmedTechStack = techStack.trim();
         if (!TechStack.isValidTechStackName(trimmedTechStack)) {
             throw new ParseException(TechStack.MESSAGE_CONSTRAINTS);
+        } else if (!TechStack.isValidTechStackNameLength(trimmedTechStack)) {
+            throw new ParseException(TechStack.MESSAGE_CONSTRAINTS_LENGTH);
+        } else {
+            return new TechStack(trimmedTechStack);
         }
-        return new TechStack(trimmedTechStack);
     }
 
     /**
@@ -146,6 +149,9 @@ public class ParserUtil {
     public static Set<TechStack> parseTechStacks(Collection<String> techStack) throws ParseException {
         requireNonNull(techStack);
         final Set<TechStack> techStackSet = new HashSet<>();
+        if (techStack.size() > 3) {
+            throw new ParseException(TechStack.MESSAGE_CONSTRAINTS_LENGTH);
+        }
         for (String techStackName : techStack) {
             techStackSet.add(parseTechStack(techStackName));
         }
@@ -163,8 +169,11 @@ public class ParserUtil {
         String trimmedTag = tag.trim();
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
+        } else if (!Tag.isValidTagNameLength(trimmedTag)) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS_LENGTH);
+        } else {
+            return new Tag(trimmedTag);
         }
-        return new Tag(trimmedTag);
     }
 
     /**
@@ -173,6 +182,9 @@ public class ParserUtil {
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {
         requireNonNull(tags);
         final Set<Tag> tagSet = new HashSet<>();
+        if (tags.size() > 3) {
+            throw new ParseException(Tag.MESSAGE_CONSTRAINTS_LENGTH);
+        }
         for (String tagName : tags) {
             tagSet.add(parseTag(tagName));
         }

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -10,6 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Tag {
 
     public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS_LENGTH = "Tag names should not exceed 15 characters, and no more than 3 tags should be added.";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;
@@ -31,6 +32,14 @@ public class Tag {
     public static boolean isValidTagName(String test) {
         return test.matches(VALIDATION_REGEX);
     }
+
+    /**
+     * Returns true if a given string is a valid tag name length.
+     */
+    public static boolean isValidTagNameLength(String test) {
+        return test.length() <= 15;
+    }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/techstack/TechStack.java
+++ b/src/main/java/seedu/address/model/techstack/TechStack.java
@@ -11,6 +11,8 @@ public class TechStack {
 
     public static final String MESSAGE_CONSTRAINTS = "Tech stack names should contain only alphanumeric characters," +
             " underscores (_), number signs (#), hyphens (-), periods (.), and plus signs (+).";
+    public static final String MESSAGE_CONSTRAINTS_LENGTH = "Tech stack names should not exceed 15 characters, and no more than 3 tech stacks should be added.";
+
     public static final String VALIDATION_REGEX = "[\\p{Alnum}+.#-]+";
     public final String techStackName;
 
@@ -30,6 +32,13 @@ public class TechStack {
      */
     public static boolean isValidTechStackName(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is a valid tech stack name length.
+     */
+    public static boolean isValidTechStackNameLength(String test) {
+        return test.length() <= 15;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonAdaptedContact.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedContact.java
@@ -91,12 +91,34 @@ class JsonAdaptedContact {
         final List<TechStack> personTechStack = new ArrayList<>();
         final List<Tag> personTags = new ArrayList<>();
 
+        if (techStack.size() >= 3) {
+            throw new IllegalValueException(TechStack.MESSAGE_CONSTRAINTS_LENGTH);
+        }
+
         for (JsonAdaptedTechStack techStack : techStack) {
-            personTechStack.add(techStack.toModelType());
+            TechStack tsModel = techStack.toModelType();
+            if (!TechStack.isValidTechStackNameLength(tsModel.techStackName)) {
+                throw new IllegalValueException(TechStack.MESSAGE_CONSTRAINTS_LENGTH);
+            } else if (!TechStack.isValidTechStackName(tsModel.techStackName)) {
+                throw new IllegalValueException(TechStack.MESSAGE_CONSTRAINTS);
+            } else {
+                personTechStack.add(tsModel);
+            }
+        }
+
+        if (tags.size() >= 3) {
+            throw new IllegalValueException(TechStack.MESSAGE_CONSTRAINTS_LENGTH);
         }
 
         for (JsonAdaptedTag tag : tags) {
-            personTags.add(tag.toModelType());
+            Tag tagModel = tag.toModelType();
+            if (!Tag.isValidTagNameLength(tagModel.tagName)) {
+                throw new IllegalValueException(TechStack.MESSAGE_CONSTRAINTS_LENGTH);
+            } else if (!Tag.isValidTagName(tagModel.tagName)) {
+                throw new IllegalValueException(TechStack.MESSAGE_CONSTRAINTS);
+            } else {
+                personTags.add(tagModel);
+            }
         }
 
         if (name == null) {

--- a/src/main/java/seedu/address/ui/ContactCard.java
+++ b/src/main/java/seedu/address/ui/ContactCard.java
@@ -75,7 +75,6 @@ public class ContactCard extends UiPart<Region> {
         address.setText("Address: " + contact.getAddress().value);
         emailLabel.setText("Email: ");
         email.setText(contact.getEmail().value);
-        //email.setText("Email: " + contact.getEmail().value);
         githubUsername.setText("@"+ contact.getGitHubUsername().username);
         contact.getTechStack().stream()
                 .sorted(Comparator.comparing(techStack -> techStack.techStackName))
@@ -90,7 +89,5 @@ public class ContactCard extends UiPart<Region> {
             mailApp.handleEmailClicked();
         });
     }
-
-
 }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -19,6 +19,7 @@ import seedu.address.model.contact.Email;
 import seedu.address.model.contact.Name;
 import seedu.address.model.contact.Phone;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.techstack.TechStack;
 
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
@@ -26,6 +27,9 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_TAG_LENGTH = "frienddddddddddddd";
+    private static final String INVALID_TS = "C++!";
+    private static final String INVALID_TS_LENGTH = "C++!dddddddddddddddd";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +37,13 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_TAG_3 = "school";
+    private static final String VALID_TAG_4 = "colleague";
+
+    private static final String VALID_TS_1 = "Python";
+    private static final String VALID_TS_2 = "Java";
+    private static final String VALID_TS_3 = "JavaScript";
+    private static final String VALID_TS_4 = "MongoDB";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -182,6 +193,16 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseTags_collectionWithInvalidTagLength_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, INVALID_TAG_LENGTH)));
+    }
+
+    @Test
+    public void parseTags_collectionWithTooManyTags_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList(VALID_TAG_1, VALID_TAG_2, VALID_TAG_3, VALID_TAG_4)));
+    }
+
+    @Test
     public void parseTags_emptyCollection_returnsEmptySet() throws Exception {
         assertTrue(ParserUtil.parseTags(Collections.emptyList()).isEmpty());
     }
@@ -192,5 +213,61 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseTS_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTechStack(null));
+    }
+
+    @Test
+    public void parseTS_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTechStack(INVALID_TS));
+    }
+
+    @Test
+    public void parseTechStack_validValueWithoutWhitespace_returnsTS() throws Exception {
+        TechStack expectedTS = new TechStack(VALID_TS_1);
+        assertEquals(expectedTS, ParserUtil.parseTechStack(VALID_TS_1));
+    }
+
+    @Test
+    public void parseTechStack_validValueWithWhitespace_returnsTrimmedTS() throws Exception {
+        String TSWithWhitespace = WHITESPACE + VALID_TS_1 + WHITESPACE;
+        TechStack expectedTS = new TechStack(VALID_TS_1);
+        assertEquals(expectedTS, ParserUtil.parseTechStack(TSWithWhitespace));
+    }
+
+    @Test
+    public void parseTechStacks_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseTechStacks(null));
+    }
+
+    @Test
+    public void parseTechStacks_collectionWithInvalidTechStacks_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTechStacks(Arrays.asList(VALID_TS_1, INVALID_TS)));
+    }
+
+    @Test
+    public void parseTechStacks_collectionWithInvalidTSLength_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTechStacks(Arrays.asList(VALID_TS_1, INVALID_TS_LENGTH)));
+    }
+
+    @Test
+    public void parseTechStacks_collectionWithTooManyTechStacks_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseTechStacks(Arrays.asList(VALID_TS_1, VALID_TS_2, VALID_TS_3, VALID_TS_4)));
+    }
+
+    @Test
+    public void parseTechStacks_emptyCollection_returnsEmptySet() throws Exception {
+        assertTrue(ParserUtil.parseTechStacks(Collections.emptyList()).isEmpty());
+    }
+
+    @Test
+    public void parseTechStacks_collectionWithValidTechStacks_returnsTSSet() throws Exception {
+        Set<TechStack> actualTechStackset = ParserUtil.parseTechStacks(Arrays.asList(VALID_TS_1, VALID_TS_2));
+        Set<TechStack> expectedTechStackset = new HashSet<TechStack>(Arrays.asList(new TechStack(VALID_TS_1), new TechStack(VALID_TS_2)));
+
+        assertEquals(expectedTechStackset, actualTechStackset);
     }
 }

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,8 +1,11 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.model.techstack.TechStack;
 
 public class TagTest {
 
@@ -21,6 +24,15 @@ public class TagTest {
     public void isValidTagName() {
         // null tag name
         assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+        assertEquals(true, TechStack.isValidTechStackName("friends"));
+        assertEquals(false, TechStack.isValidTechStackName("friends!!"));
     }
 
+    @Test
+    public void isValidTagNameLength() {
+        // null tag name
+        assertThrows(NullPointerException.class, () -> Tag.isValidTagName(null));
+        assertEquals(true, TechStack.isValidTechStackNameLength("friends"));
+        assertEquals(false, TechStack.isValidTechStackNameLength("friendssssssssssssssssssss"));
+    }
 }

--- a/src/test/java/seedu/address/model/techstack/TechStackTest.java
+++ b/src/test/java/seedu/address/model/techstack/TechStackTest.java
@@ -24,6 +24,13 @@ public class TechStackTest {
     public void isValidTechStackName() {
         assertThrows(NullPointerException.class, () -> TechStack.isValidTechStackName(null));
         assertEquals(true, TechStack.isValidTechStackName("C++"));
+        assertEquals(false, TechStack.isValidTechStackName("C++$$$"));
     }
 
+    @Test
+    public void isValidTechStackNameLength() {
+        assertThrows(NullPointerException.class, () -> TechStack.isValidTechStackName(null));
+        assertEquals(true, TechStack.isValidTechStackNameLength("C++"));
+        assertEquals(false, TechStack.isValidTechStackNameLength("C+++++++++++++++++++++"));
+    }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedContactTest.java
@@ -125,7 +125,7 @@ public class JsonAdaptedContactTest {
     @Test
     public void toModelType_nullGitHubUsername_throwsIllegalValueException() {
         JsonAdaptedContact contact = new JsonAdaptedContact(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_PROFILE_PICTURE, VALID_TECH_STACK,  VALID_TAGS);
+                null, VALID_PROFILE_PICTURE, VALID_TECH_STACK, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, GitHubUsername.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, contact::toModelType);
     }
@@ -140,4 +140,37 @@ public class JsonAdaptedContactTest {
         assertThrows(IllegalValueException.class, contact::toModelType);
     }
 
+    @Test
+    public void toModelType_tooManyTags_throwsIllegalValueException() {
+        List<JsonAdaptedTag> tooManyTags = new ArrayList<>(VALID_TAGS);
+        tooManyTags.add(new JsonAdaptedTag("my homie1"));
+        tooManyTags.add(new JsonAdaptedTag("my homie2"));
+        tooManyTags.add(new JsonAdaptedTag("my homie3"));
+        JsonAdaptedContact contact =
+                new JsonAdaptedContact(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_GITHUB_USERNAME, VALID_PROFILE_PICTURE, VALID_TECH_STACK, tooManyTags);
+        assertThrows(IllegalValueException.class, contact::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidTechStacks_throwsIllegalValueException() {
+        List<JsonAdaptedTechStack> invalidTS = new ArrayList<>(VALID_TECH_STACK);
+        invalidTS.add(new JsonAdaptedTechStack(INVALID_TECH_STACK));
+        JsonAdaptedContact contact =
+                new JsonAdaptedContact(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_GITHUB_USERNAME, VALID_PROFILE_PICTURE, invalidTS, VALID_TAGS);
+        assertThrows(IllegalValueException.class, contact::toModelType);
+    }
+
+    @Test
+    public void toModelType_tooManyTechStacks_throwsIllegalValueException() {
+        List<JsonAdaptedTechStack> tooManyTS = new ArrayList<>(VALID_TECH_STACK);
+        tooManyTS.add(new JsonAdaptedTechStack("my ts1"));
+        tooManyTS.add(new JsonAdaptedTechStack("my ts2"));
+        tooManyTS.add(new JsonAdaptedTechStack("my ts3"));
+        JsonAdaptedContact contact =
+                new JsonAdaptedContact(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_GITHUB_USERNAME, VALID_PROFILE_PICTURE, tooManyTS, VALID_TAGS);
+        assertThrows(IllegalValueException.class, contact::toModelType);
+    }
 }


### PR DESCRIPTION
There was a bug where a very long tech stack/tag would take up too much space on the contact card. 
The decision was made to limit the number of tech stacks and tags, as well as limit the length of each to 15 characters. 
Tests and UG also updated alongside these changes. 