### PR TITLE
Adjust regex to allow for underscores for techstacks

### DIFF
--- a/src/main/java/seedu/address/model/techstack/TechStack.java
+++ b/src/main/java/seedu/address/model/techstack/TechStack.java
@@ -13,7 +13,7 @@ public class TechStack {
             " underscores (_), number signs (#), hyphens (-), periods (.), and plus signs (+).";
     public static final String MESSAGE_CONSTRAINTS_LENGTH = "Tech stack names should not exceed 15 characters, and no more than 3 tech stacks should be added.";
 
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}+.#-]+";
+    public static final String VALIDATION_REGEX = "[a-zA-Z0-9_+.#-]+";
     public final String techStackName;
     public Integer rating = null;
 

--- a/src/test/java/seedu/address/model/techstack/TechStackTest.java
+++ b/src/test/java/seedu/address/model/techstack/TechStackTest.java
@@ -25,7 +25,11 @@ public class TechStackTest {
     public void isValidTechStackName() {
         assertThrows(NullPointerException.class, () -> TechStack.isValidTechStackName(null));
         assertEquals(true, TechStack.isValidTechStackName("C++"));
-        assertEquals(false, TechStack.isValidTechStackName("C++$$$"));
+        assertEquals(true, TechStack.isValidTechStackName("C+_.-#")); // test all valid non-alphanumeric characters
+        assertEquals(true, TechStack.isValidTechStackName("Cc++123###")); // test mix of alphanumeric and non-alphanumeric
+        assertEquals(false, TechStack.isValidTechStackName("C++!!!"));
+        assertEquals(false, TechStack.isValidTechStackName("123///"));
+        assertEquals(false, TechStack.isValidTechStackName("Java?~`';:"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #148 

This is justifiable as a fix, not an enhancement as there was an error in our regex that resulted in tech stack names containing "_" to be incorrectly filtered out